### PR TITLE
Add gateway issues/sections

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -57,4 +57,3 @@ func (ghc *Client) FetchIssues(githubOrg, githubRepo, label string) *Changelog {
 
 	return changelog
 }
-

--- a/pkg/github/issue.go
+++ b/pkg/github/issue.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	brokerLabel     = "Scope: broker"
+	gatewayLabel	= "Scope: gateway"
 	javaClientLabel = "Scope: clients/java"
 	goClientLabel   = "Scope: clients/go"
 
@@ -15,7 +16,7 @@ const (
 	docsLabel        = "Type: Docs"
 )
 
-var knownLabels = []string{brokerLabel, javaClientLabel, goClientLabel, enhancementLabel, bugLabel, docsLabel}
+var knownLabels = []string{brokerLabel, gatewayLabel, javaClientLabel, goClientLabel, enhancementLabel, bugLabel, docsLabel}
 
 type Issue struct {
 	title       *string
@@ -50,6 +51,10 @@ func mapLabels(labelList []github.Label) map[string]bool {
 
 func (i *Issue) HasBrokerLabel() bool {
 	return i.hasLabel(brokerLabel)
+}
+
+func (i *Issue) HasGatewayLabel() bool {
+	return i.hasLabel(gatewayLabel)
 }
 
 func (i *Issue) HasJavaClientLabel() bool {

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -38,6 +38,23 @@ func TestIssue_HasBrokerLabel(t *testing.T) {
 	}
 }
 
+func TestIssue_HasGatewayLabel(t *testing.T) {
+	tests := map[string]struct {
+		issue    *Issue
+		hasLabel bool
+	}{
+		"No Label":        {issue: createIssue("", 0, "", false), hasLabel: false},
+		"Different Label": {issue: createIssue("", 0, "", false, javaClientLabel), hasLabel: false},
+		"Has Label":       {issue: createIssue("", 0, "", false, gatewayLabel), hasLabel: true},
+		"Multiple Labels": {issue: createIssue("", 0, "", false, javaClientLabel, enhancementLabel, gatewayLabel), hasLabel: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.hasLabel, tc.issue.HasGatewayLabel())
+		})
+	}
+}
+
 func TestIssue_HasJavaClientLabel(t *testing.T) {
 	tests := map[string]struct {
 		issue    *Issue

--- a/pkg/github/section.go
+++ b/pkg/github/section.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	brokerSection     = "Broker"
+	gatewaySection    = "Gateway"
 	javaClientSection = "Java Client"
 	goClientSection   = "Go Client"
 	miscSection       = "Misc"
@@ -25,6 +26,10 @@ func NewSection() *Section {
 func (s *Section) AddIssue(issue *Issue) *Section {
 	if issue.HasBrokerLabel() {
 		s.addIssueToSection(brokerSection, issue)
+	}
+
+	if issue.HasGatewayLabel() {
+		s.addIssueToSection(gatewaySection, issue)
 	}
 
 	if issue.HasJavaClientLabel() {
@@ -48,6 +53,10 @@ func (s *Section) addIssueToSection(section string, issue *Issue) {
 
 func (s *Section) GetBrokerIssues() []*Issue {
 	return s.getIssues(brokerSection)
+}
+
+func (s *Section) GetGatewayIssues() []*Issue {
+	return s.getIssues(gatewaySection)
 }
 
 func (s *Section) GetJavaClientIssues() []*Issue {
@@ -74,6 +83,7 @@ func (s *Section) String() string {
 	var b bytes.Buffer
 
 	b.WriteString(sectionToString(brokerSection, s.GetBrokerIssues()))
+	b.WriteString(sectionToString(gatewaySection, s.GetGatewayIssues()))
 	b.WriteString(sectionToString(javaClientSection, s.GetJavaClientIssues()))
 	b.WriteString(sectionToString(goClientSection, s.GetGoClientIssues()))
 	b.WriteString(sectionToString(miscSection, s.GetMiscIssues()))

--- a/pkg/github/section_test.go
+++ b/pkg/github/section_test.go
@@ -30,6 +30,29 @@ func TestSection_GetBrokerIssues(t *testing.T) {
 	}
 }
 
+func TestSection_GetGatewayIssues(t *testing.T) {
+	tests := map[string]struct {
+		section *Section
+		size    int
+	}{
+		"No Issues":       {section: NewSection(), size: 0},
+		"Different Issue": {section: NewSection().AddIssue(createIssueWithLabel("unknown")), size: 0},
+		"One Issue":       {section: NewSection().AddIssue(createIssueWithLabel(gatewayLabel)), size: 1},
+		"Multiple Issues": {
+			section: NewSection().
+				AddIssue(createIssueWithLabel(gatewayLabel, enhancementLabel)).
+				AddIssue(createIssueWithLabel(bugLabel, gatewayLabel)).
+				AddIssue(createIssueWithLabel(javaClientLabel)),
+			size: 2,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.size, len(tc.section.GetGatewayIssues()))
+		})
+	}
+}
+
 func TestSection_GetJavaClientIssues(t *testing.T) {
 	tests := map[string]struct {
 		section *Section


### PR DESCRIPTION
Adds a section to the changelog for issues with the gateway scope. I expect we will have more of these in the upcoming months, and it makes sense to have them split off from the broker.