### PR TITLE
fix(gitlog): fixes regex used to pick up issues

### DIFF
--- a/pkg/gitlog/gitlog.go
+++ b/pkg/gitlog/gitlog.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	lineRegex = regexp.MustCompile(`(?im)^\s*(closes?|related|relates|merges?|back\s?ports?|)\s+.*$`)
+	lineRegex = regexp.MustCompile(`(?im)^ *(closes?|related|relates|merges?|back\s?ports?|) +.*$`)
 	idRegex   = regexp.MustCompile(`#(\d+)`)
 )
 

--- a/pkg/gitlog/gitlog.go
+++ b/pkg/gitlog/gitlog.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	lineRegex = regexp.MustCompile(`(?im)^ *(closes?|related|relates|merges?|back\s?ports?|) +.*$`)
+	lineRegex = regexp.MustCompile(`(?im)^ *(closes?|related|relates|merges?|back\s?ports?) +.*$`)
 	idRegex   = regexp.MustCompile(`#(\d+)`)
 )
 


### PR DESCRIPTION
The gitlog module analyzes each commit line by line and finds all lines
which include specific keywords, e.g. "closes", "related", "merges",
etc. In those lines, it then looks for an issue number prefixed by a #.
What was wrong before was we looked for the keywords prefixed/suffixed
by `\s`, which includes newlines, so you could be looking at more than
one line. At any rate, we now use the space character specifically.
Using regexes is probably not the best thing, as it's unreliable and
doesn't play nice with commits from, say, dependabot. But it works well
enough for now.