### PR TITLE
Update to use new Zeebe labels

### DIFF
--- a/pkg/github/changelog.go
+++ b/pkg/github/changelog.go
@@ -10,6 +10,7 @@ type Changelog struct {
 	enhancements *Section
 	fixes        *Section
 	docs         []*Issue
+	toil         []*Issue
 	pullRequests []*Issue
 }
 
@@ -19,6 +20,7 @@ func NewChangelog(title string) *Changelog {
 		enhancements: NewSection(),
 		fixes:        NewSection(),
 		docs:         []*Issue{},
+		toil:         []*Issue{},
 		pullRequests: []*Issue{},
 	}
 }
@@ -36,6 +38,9 @@ func (c *Changelog) AddIssue(issue *Issue) *Changelog {
 		if issue.HasDocsLabel() {
 			c.docs = append(c.docs, issue)
 		}
+		if issue.HasToilLabel() {
+			c.toil = append(c.toil, issue)
+		}
 	}
 	return c
 }
@@ -48,6 +53,7 @@ func (c *Changelog) String() string {
 	chapterToString(&b, "Enhancements", c.enhancements)
 	chapterToString(&b, "Bug Fixes", c.fixes)
 
+	issueListToString(&b, "Maintenance", c.toil)
 	issueListToString(&b, "Documentation", c.docs)
 	issueListToString(&b, "Merged Pull Requests", c.pullRequests)
 

--- a/pkg/github/issue.go
+++ b/pkg/github/issue.go
@@ -6,17 +6,28 @@ import (
 )
 
 const (
-	brokerLabel     = "Scope: broker"
-	gatewayLabel    = "Scope: gateway"
-	javaClientLabel = "Scope: clients/java"
-	goClientLabel   = "Scope: clients/go"
-
-	enhancementLabel = "Type: Enhancement"
-	bugLabel         = "Type: Bug"
-	docsLabel        = "Type: Docs"
+	brokerLabel     = "scope/broker"
+	gatewayLabel    = "scope/gateway"
+	javaClientLabel = "scope/clients-java"
+	goClientLabel   = "scope/clients-go"
+	zbctlLabel      = "scope/zbctl"
+	featureLabel    = "kind/feature"
+	bugLabel        = "kind/bug"
+	docsLabel       = "kind/documentation"
+	toilLabel       = "kind/toil"
 )
 
-var knownLabels = []string{brokerLabel, gatewayLabel, javaClientLabel, goClientLabel, enhancementLabel, bugLabel, docsLabel}
+var knownLabels = []string{
+	brokerLabel,
+	gatewayLabel,
+	javaClientLabel,
+	goClientLabel,
+	featureLabel,
+	bugLabel,
+	docsLabel,
+	zbctlLabel,
+	toilLabel,
+}
 
 type Issue struct {
 	title       *string
@@ -66,7 +77,7 @@ func (i *Issue) HasGoClientLabel() bool {
 }
 
 func (i *Issue) HasEnhancementLabel() bool {
-	return i.hasLabel(enhancementLabel)
+	return i.hasLabel(featureLabel)
 }
 
 func (i *Issue) HasBugLabel() bool {
@@ -75,6 +86,14 @@ func (i *Issue) HasBugLabel() bool {
 
 func (i *Issue) HasDocsLabel() bool {
 	return i.hasLabel(docsLabel)
+}
+
+func (i *Issue) HasZbctlLabel() bool {
+	return i.hasLabel(zbctlLabel)
+}
+
+func (i *Issue) HasToilLabel() bool {
+	return i.hasLabel(toilLabel)
 }
 
 func (i *Issue) hasLabel(label string) bool {

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -29,7 +29,7 @@ func TestIssue_HasBrokerLabel(t *testing.T) {
 		"No Label":        {issue: createIssue("", 0, "", false), hasLabel: false},
 		"Different Label": {issue: createIssue("", 0, "", false, javaClientLabel), hasLabel: false},
 		"Has Label":       {issue: createIssue("", 0, "", false, brokerLabel), hasLabel: true},
-		"Multiple Labels": {issue: createIssue("", 0, "", false, javaClientLabel, enhancementLabel, brokerLabel), hasLabel: true},
+		"Multiple Labels": {issue: createIssue("", 0, "", false, javaClientLabel, featureLabel, brokerLabel), hasLabel: true},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -46,7 +46,7 @@ func TestIssue_HasGatewayLabel(t *testing.T) {
 		"No Label":        {issue: createIssue("", 0, "", false), hasLabel: false},
 		"Different Label": {issue: createIssue("", 0, "", false, javaClientLabel), hasLabel: false},
 		"Has Label":       {issue: createIssue("", 0, "", false, gatewayLabel), hasLabel: true},
-		"Multiple Labels": {issue: createIssue("", 0, "", false, javaClientLabel, enhancementLabel, gatewayLabel), hasLabel: true},
+		"Multiple Labels": {issue: createIssue("", 0, "", false, javaClientLabel, featureLabel, gatewayLabel), hasLabel: true},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestIssue_HasJavaClientLabel(t *testing.T) {
 		"No Label":        {issue: createIssue("", 0, "", false), hasLabel: false},
 		"Different Label": {issue: createIssue("", 0, "", false, brokerLabel), hasLabel: false},
 		"Has Label":       {issue: createIssue("", 0, "", false, javaClientLabel), hasLabel: true},
-		"Multiple Labels": {issue: createIssue("", 0, "", false, javaClientLabel, enhancementLabel, brokerLabel), hasLabel: true},
+		"Multiple Labels": {issue: createIssue("", 0, "", false, javaClientLabel, featureLabel, brokerLabel), hasLabel: true},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -80,7 +80,7 @@ func TestIssue_HasGoClientLabel(t *testing.T) {
 		"No Label":        {issue: createIssue("", 0, "", false), hasLabel: false},
 		"Different Label": {issue: createIssue("", 0, "", false, javaClientLabel), hasLabel: false},
 		"Has Label":       {issue: createIssue("", 0, "", false, goClientLabel), hasLabel: true},
-		"Multiple Labels": {issue: createIssue("", 0, "", false, goClientLabel, enhancementLabel, brokerLabel), hasLabel: true},
+		"Multiple Labels": {issue: createIssue("", 0, "", false, goClientLabel, featureLabel, brokerLabel), hasLabel: true},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -96,8 +96,8 @@ func TestIssue_HasEnhancementLabel(t *testing.T) {
 	}{
 		"No Label":        {issue: createIssue("", 0, "", false), hasLabel: false},
 		"Different Label": {issue: createIssue("", 0, "", false, javaClientLabel), hasLabel: false},
-		"Has Label":       {issue: createIssue("", 0, "", false, enhancementLabel), hasLabel: true},
-		"Multiple Labels": {issue: createIssue("", 0, "", false, javaClientLabel, enhancementLabel, brokerLabel), hasLabel: true},
+		"Has Label":       {issue: createIssue("", 0, "", false, featureLabel), hasLabel: true},
+		"Multiple Labels": {issue: createIssue("", 0, "", false, javaClientLabel, featureLabel, brokerLabel), hasLabel: true},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -136,6 +136,23 @@ func TestIssue_HasDocsLabel(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.hasLabel, tc.issue.HasDocsLabel())
+		})
+	}
+}
+
+func TestIssue_HasToilLabel(t *testing.T) {
+	tests := map[string]struct {
+		issue    *Issue
+		hasLabel bool
+	}{
+		"No Label":        {issue: createIssue("", 0, "", false), hasLabel: false},
+		"Different Label": {issue: createIssue("", 0, "", false, javaClientLabel), hasLabel: false},
+		"Has Label":       {issue: createIssue("", 0, "", false, toilLabel), hasLabel: true},
+		"Multiple Labels": {issue: createIssue("", 0, "", false, javaClientLabel, brokerLabel, toilLabel), hasLabel: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.hasLabel, tc.issue.HasToilLabel())
 		})
 	}
 }

--- a/pkg/github/section.go
+++ b/pkg/github/section.go
@@ -10,6 +10,7 @@ const (
 	gatewaySection    = "Gateway"
 	javaClientSection = "Java Client"
 	goClientSection   = "Go Client"
+	zbctlSection      = "zbctl"
 	miscSection       = "Misc"
 )
 
@@ -24,24 +25,33 @@ func NewSection() *Section {
 }
 
 func (s *Section) AddIssue(issue *Issue) *Section {
+	hasSection := false
 	if issue.HasBrokerLabel() {
 		s.addIssueToSection(brokerSection, issue)
+		hasSection = true
 	}
 
 	if issue.HasGatewayLabel() {
 		s.addIssueToSection(gatewaySection, issue)
+		hasSection = true
 	}
 
 	if issue.HasJavaClientLabel() {
 		s.addIssueToSection(javaClientSection, issue)
+		hasSection = true
 	}
 
 	if issue.HasGoClientLabel() {
 		s.addIssueToSection(goClientSection, issue)
+		hasSection = true
 	}
 
-	isMisc := !(issue.HasBrokerLabel() || issue.HasJavaClientLabel() || issue.HasGoClientLabel())
-	if isMisc {
+	if issue.HasZbctlLabel() {
+		s.addIssueToSection(zbctlSection, issue)
+		hasSection = true
+	}
+
+	if !hasSection {
 		s.addIssueToSection(miscSection, issue)
 	}
 	return s
@@ -67,6 +77,10 @@ func (s *Section) GetGoClientIssues() []*Issue {
 	return s.getIssues(goClientSection)
 }
 
+func (s *Section) GetZbctlIssues() []*Issue {
+	return s.getIssues(zbctlSection)
+}
+
 func (s *Section) GetMiscIssues() []*Issue {
 	return s.getIssues(miscSection)
 }
@@ -86,6 +100,7 @@ func (s *Section) String() string {
 	b.WriteString(sectionToString(gatewaySection, s.GetGatewayIssues()))
 	b.WriteString(sectionToString(javaClientSection, s.GetJavaClientIssues()))
 	b.WriteString(sectionToString(goClientSection, s.GetGoClientIssues()))
+	b.WriteString(sectionToString(zbctlSection, s.GetZbctlIssues()))
 	b.WriteString(sectionToString(miscSection, s.GetMiscIssues()))
 
 	return b.String()

--- a/pkg/github/section_test.go
+++ b/pkg/github/section_test.go
@@ -17,7 +17,7 @@ func TestSection_GetBrokerIssues(t *testing.T) {
 		"One Issue":       {section: NewSection().AddIssue(createIssueWithLabel(brokerLabel)), size: 1},
 		"Multiple Issues": {
 			section: NewSection().
-				AddIssue(createIssueWithLabel(brokerLabel, enhancementLabel)).
+				AddIssue(createIssueWithLabel(brokerLabel, featureLabel)).
 				AddIssue(createIssueWithLabel(bugLabel, brokerLabel)).
 				AddIssue(createIssueWithLabel(javaClientLabel)),
 			size: 2,
@@ -40,7 +40,7 @@ func TestSection_GetGatewayIssues(t *testing.T) {
 		"One Issue":       {section: NewSection().AddIssue(createIssueWithLabel(gatewayLabel)), size: 1},
 		"Multiple Issues": {
 			section: NewSection().
-				AddIssue(createIssueWithLabel(gatewayLabel, enhancementLabel)).
+				AddIssue(createIssueWithLabel(gatewayLabel, featureLabel)).
 				AddIssue(createIssueWithLabel(bugLabel, gatewayLabel)).
 				AddIssue(createIssueWithLabel(javaClientLabel)),
 			size: 2,
@@ -63,7 +63,7 @@ func TestSection_GetJavaClientIssues(t *testing.T) {
 		"One Issue":       {section: NewSection().AddIssue(createIssueWithLabel(javaClientLabel)), size: 1},
 		"Multiple Issues": {
 			section: NewSection().
-				AddIssue(createIssueWithLabel(javaClientLabel, enhancementLabel)).
+				AddIssue(createIssueWithLabel(javaClientLabel, featureLabel)).
 				AddIssue(createIssueWithLabel(bugLabel, javaClientLabel)).
 				AddIssue(createIssueWithLabel(brokerLabel)),
 			size: 2,
@@ -86,7 +86,7 @@ func TestSection_GetGoClientIssues(t *testing.T) {
 		"One Issue":       {section: NewSection().AddIssue(createIssueWithLabel(goClientLabel)), size: 1},
 		"Multiple Issues": {
 			section: NewSection().
-				AddIssue(createIssueWithLabel(goClientLabel, enhancementLabel)).
+				AddIssue(createIssueWithLabel(goClientLabel, featureLabel)).
 				AddIssue(createIssueWithLabel(bugLabel, goClientLabel)).
 				AddIssue(createIssueWithLabel(brokerLabel)),
 			size: 2,
@@ -109,7 +109,7 @@ func TestSection_GetMiscIssues(t *testing.T) {
 		"One Issue":       {section: NewSection().AddIssue(createIssueWithLabel()), size: 1},
 		"Multiple Issues": {
 			section: NewSection().
-				AddIssue(createIssueWithLabel(enhancementLabel)).
+				AddIssue(createIssueWithLabel(featureLabel)).
 				AddIssue(createIssueWithLabel(bugLabel)).
 				AddIssue(createIssueWithLabel(brokerLabel)),
 			size: 2,


### PR DESCRIPTION
Updates labels such that they match the new Zeebe repo labels. Additionally adds a maintenance section using `kind/toil` when generating the changelog.