### PR TITLE
docs: add description of commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,25 @@
 [![codecov](https://codecov.io/gh/zeebe-io/zeebe-changelog/branch/master/graph/badge.svg)](https://codecov.io/gh/zeebe-io/zeebe-changelog)
 
 Generate changelog for [Zeebe](github.com/zeebe-io/zeebe) project.
+
+
+## Example usage
+
+```sh
+  export ZCL_FROM_REV=PREV_VERSION
+  export ZCL_TARGET_REV=TARGET_VERSION
+
+  # This will add labels to the issues in GitHub. You can verify this step by looking at closed issues. They should now be tagged with the release.
+  zcl add-labels \
+    --token=$GITHUB_TOKEN \
+    --from=$ZCL_FROM_REV \
+    --target=$ZCL_TARGET_REV \
+    --label="version:$ZCL_TARGET_REV" \
+    --org camunda --repo zeebe
+
+  # This command will print markdown code to the console. You will need to manually insert this output into the release draft.
+  zcl generate \
+     --token=$GITHUB_TOKEN \
+     --label="version:$ZCL_TARGET_REV" \
+     --org camunda --repo zeebe
+```


### PR DESCRIPTION
Just to add some more examples to the README, it felt so lost.