### PR TITLE
fix: use date of start tag

### DIFF
--- a/pkg/gitlog/gitlog.go
+++ b/pkg/gitlog/gitlog.go
@@ -16,10 +16,19 @@ var (
 func GetHistory(path, start, end string) string {
 	logRange := fmt.Sprintf("%s..%s", start, end)
 
+	// get date from start (to handle cases where we merged git histories)
+	getStartDateCmd := exec.Command("git", "-C", path, "log", "-1", "--format=%ai", start)
+	log.Println(getStartDateCmd)
+	out, err := getStartDateCmd.CombinedOutput()
+	startDate := string(out)
+	if err != nil {
+		log.Fatal(startDate, err)
+	}
+
 	// use git command til git lib implements range feature, see https://github.com/src-d/go-git/issues/1166
-	command := exec.Command("git", "-C", path, "log", logRange, "--merges", "--")
+	command := exec.Command("git", "-C", path, "log", logRange, "--merges", "--since", startDate, "--")
 	log.Println(command)
-	out, err := command.CombinedOutput()
+	out, err = command.CombinedOutput()
 	result := string(out)
 
 	if err != nil {

--- a/pkg/gitlog/gitlog_test.go
+++ b/pkg/gitlog/gitlog_test.go
@@ -10,7 +10,7 @@ import "github.com/stretchr/testify/assert"
 func TestGitHistory(t *testing.T) {
 
 	// clone zeebe repo to test with merge commits
-	command := exec.Command("git", "clone", "https://github.com/camunda/zeebe.git", "zeebe")
+	command := exec.Command("git", "clone", "-b", "8.5.0", "https://github.com/camunda/zeebe.git", "zeebe")
 	log.Println(command)
 
 	out, _ := command.CombinedOutput()
@@ -24,7 +24,7 @@ func TestGitHistory(t *testing.T) {
 		size  int
 	}{
 		"First commit in zcl":        {path: ".", start: "7b86247", end: "7ab8381", size: 0},
-		"Between tags in zeebe repo": {path: "zeebe", start: "8.5.0", end: "8.6.0-alpha1", size: 2010863},
+		"Between tags in zeebe repo": {path: "zeebe", start: "8.5.0", end: "8.6.0-alpha1", size: 1558638},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
To be able to handle git history merges, we use the --since filter of git such that our returned commits are only starting from the start tag date.

This additional filter with together the merge only commits we are able to create a correct changelog again

See related https://github.com/camunda/zeebe/issues/18451#issuecomment-2109642001

I already tried it out and were able to reduce the referenced issues from 880 to ~440


As we adding the usage of the `--since` git log flag into the zcl this change is transparent to the user, and it allows to correctly work easily also on the 8.6.0 release. Without changing any docs in the release process as well.