### PR TITLE
feat: add --dry-run flag for add-label command and print to-be-labelled issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Release](https://img.shields.io/github/release/camunda/zeebe-changelog.svg?style=flat-square)](https://github.com/camunda/zeebe-changelog/releases/latest)
 [![codecov](https://codecov.io/gh/camunda/zeebe-changelog/branch/master/graph/badge.svg)](https://codecov.io/gh/camunda/zeebe-changelog)
 
-Generate changelog for [Zeebe](github.com/camunda/camunda) project.
+Generate changelog for [Camunda 8](github.com/camunda/camunda) project.
 
 
 ## Example usage
@@ -19,7 +19,7 @@ Generate changelog for [Zeebe](github.com/camunda/camunda) project.
     --from=$ZCL_FROM_REV \
     --target=$ZCL_TARGET_REV \
     --label="version:$ZCL_TARGET_REV" \
-    --org camunda --repo zeebe
+    --org camunda --repo camunda
 
   # Optional: Configure the number of concurrent workers (default: 10)
   # This can speed up labeling of large numbers of issues
@@ -28,14 +28,23 @@ Generate changelog for [Zeebe](github.com/camunda/camunda) project.
     --from=$ZCL_FROM_REV \
     --target=$ZCL_TARGET_REV \
     --label="version:$ZCL_TARGET_REV" \
-    --org camunda --repo zeebe \
+    --org camunda --repo camunda \
     --workers=20
+
+  # Optional: Dry run to preview which issues would be labeled without making any changes
+  zcl add-labels \
+    --token=$GITHUB_TOKEN \
+    --from=$ZCL_FROM_REV \
+    --target=$ZCL_TARGET_REV \
+    --label="version:$ZCL_TARGET_REV" \
+    --org camunda --repo camunda \
+    --dry-run
 
   # This command will print markdown code to the console. You will need to manually insert this output into the release draft.
   zcl generate \
      --token=$GITHUB_TOKEN \
      --label="version:$ZCL_TARGET_REV" \
-     --org camunda --repo zeebe
+     --org camunda --repo camunda
 ```
 ## Release ZCL
 


### PR DESCRIPTION
Always print issues to be labelled when running `zcl add-labels` (example of usage: https://github.com/camunda/camunda/blob/93cb6eb6733c449caa7197a7f53f25f741772f3f/.github/workflows/camunda-platform-release.yml#L1054)
In the `--dry-run` mode, do not actually amend the labels of issues/PRs (easier debugging).

Example:
```
2026/02/18 21:23:55 Collection issue ids
2026/02/18 21:23:55 [dry-run] Would add label version:8.8.13 to 4 issues in camunda/camunda
  https://github.com/camunda/camunda/issues/43086
  https://github.com/camunda/camunda/issues/31111
  https://github.com/camunda/camunda/issues/45929
  https://github.com/camunda/camunda/issues/44818
```