### PR TITLE
fix: include kind/task issues in the changelog as well

### DIFF
--- a/pkg/github/changelog.go
+++ b/pkg/github/changelog.go
@@ -11,6 +11,7 @@ type Changelog struct {
 	fixes        *Section
 	docs         []*Issue
 	toil         []*Issue
+	task         []*Issue
 	pullRequests []*Issue
 }
 
@@ -21,6 +22,7 @@ func NewChangelog(title string) *Changelog {
 		fixes:        NewSection(),
 		docs:         []*Issue{},
 		toil:         []*Issue{},
+		task:         []*Issue{},
 		pullRequests: []*Issue{},
 	}
 }
@@ -41,6 +43,9 @@ func (c *Changelog) AddIssue(issue *Issue) *Changelog {
 		if issue.HasToilLabel() {
 			c.toil = append(c.toil, issue)
 		}
+		if issue.HasTaskLabel() {
+			c.task = append(c.task, issue)
+		}
 	}
 	return c
 }
@@ -54,6 +59,7 @@ func (c *Changelog) String() string {
 	chapterToString(&b, "Bug Fixes", c.fixes)
 
 	issueListToString(&b, "Maintenance", c.toil)
+	issueListToString(&b, "Task", c.task)
 	issueListToString(&b, "Documentation", c.docs)
 	issueListToString(&b, "Merged Pull Requests", c.pullRequests)
 

--- a/pkg/github/issue.go
+++ b/pkg/github/issue.go
@@ -15,6 +15,7 @@ const (
 	bugLabel        = "kind/bug"
 	docsLabel       = "kind/documentation"
 	toilLabel       = "kind/toil"
+	taskLabel       = "kind/task"
 )
 
 var knownLabels = []string{
@@ -27,6 +28,7 @@ var knownLabels = []string{
 	docsLabel,
 	zbctlLabel,
 	toilLabel,
+	taskLabel,
 }
 
 type Issue struct {
@@ -94,6 +96,10 @@ func (i *Issue) HasZbctlLabel() bool {
 
 func (i *Issue) HasToilLabel() bool {
 	return i.hasLabel(toilLabel)
+}
+
+func (i *Issue) HasTaskLabel() bool {
+	return i.hasLabel(taskLabel)
 }
 
 func (i *Issue) hasLabel(label string) bool {

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -157,6 +157,23 @@ func TestIssue_HasToilLabel(t *testing.T) {
 	}
 }
 
+func TestIssue_HasTaskLabel(t *testing.T) {
+	tests := map[string]struct {
+		issue    *Issue
+		hasLabel bool
+	}{
+		"No Label":        {issue: createIssue("", 0, "", false), hasLabel: false},
+		"Different Label": {issue: createIssue("", 0, "", false, javaClientLabel), hasLabel: false},
+		"Has Label":       {issue: createIssue("", 0, "", false, taskLabel), hasLabel: true},
+		"Multiple Labels": {issue: createIssue("", 0, "", false, javaClientLabel, brokerLabel, taskLabel), hasLabel: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.hasLabel, tc.issue.HasTaskLabel())
+		})
+	}
+}
+
 func TestIssue_String(t *testing.T) {
 	issue := createIssue("Test Issue", 1234, "https://github.com", false)
 	assert.Equal(t, "Test Issue ([#1234](https://github.com))", issue.String())


### PR DESCRIPTION
Adds support for a new "Task" label in the changelog generation process. Issues with the `kind/task` label are now recognized, categorized, and displayed in the generated changelog, similar to existing labels like "Toil" and "Bug".

---

context: https://camunda.slack.com/archives/C06UWQNCU7M/p1771427372406549
example issue: https://github.com/camunda/camunda/issues/44131