### PR TITLE
fix: ensure label exists before labelling issues

### DIFF
--- a/cmd/zcl/main.go
+++ b/cmd/zcl/main.go
@@ -216,17 +216,11 @@ func addLabels(_ context.Context, cmd *cli.Command) error {
 	}
 
 	client := github.NewClient(token)
+	client.EnsureLabelExists(githubOrg, githubRepo, label, dryRun)
 
 	if dryRun {
-		exists, err := client.LabelExists(githubOrg, githubRepo, label)
-		if err != nil {
-			log.Fatalln(err)
-		}
-		log.Printf("[dry-run] Label %q exists in %s/%s: %t\n", label, githubOrg, githubRepo, exists)
 		return nil
 	}
-
-	client.EnsureLabelExists(githubOrg, githubRepo, label)
 
 	log.Println("Updating", issueCount, "issues with", numWorkers, "workers")
 	bar := progress.NewProgressBar(issueCount)

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -36,13 +36,15 @@ func NewClient(token string) *Client {
 	}
 }
 
-func (ghc *Client) EnsureLabelExists(githubOrg, githubRepo, label string) {
+func (ghc *Client) EnsureLabelExists(githubOrg, githubRepo, label string, dryRun bool) {
 	exists, err := ghc.LabelExists(githubOrg, githubRepo, label)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	if exists {
+	log.Printf("Does label %q exist in %s/%s: %t\n", label, githubOrg, githubRepo, exists)
+
+	if dryRun || exists {
 		return
 	}
 


### PR DESCRIPTION
Ensure a version label (e.g. `version:x.y.z`) exists in the target repository upfront, to avoid concurrency problems, like here: https://github.com/camunda/camunda/actions/runs/22336005919/job/64631932948

```
2026/02/24 04:47:10 POST https://api.github.com/repos/camunda/camunda/issues/46528/labels: 422 Validation Failed [{Resource:Label Field:name Code:invalid Message:}]
```

The issue started to be more prominent with https://github.com/camunda/zeebe-changelog/pull/24

Example local dry run afterwards with a non-existing label:

```
2026/02/24 12:25:05 Fetching git history in dir . for 8.8.12 .. 8.8.13
2026/02/24 12:25:05 /opt/homebrew/bin/git -C . log -1 --format=%ai 8.8.12
2026/02/24 12:25:05 /opt/homebrew/bin/git -C . log 8.8.12..8.8.13 --merges --since 2026-02-17 12:46:58 +0000
 --
2026/02/24 12:25:05 Collection issue ids
2026/02/24 12:25:05 [dry-run] Would add label version:8.8.15 to 4 issues in camunda/camunda
  https://github.com/camunda/camunda/issues/43086
  https://github.com/camunda/camunda/issues/31111
  https://github.com/camunda/camunda/issues/45929
  https://github.com/camunda/camunda/issues/44818
2026/02/24 12:25:06 Does label "version:8.8.15" exist in camunda/camunda: false
```