### PR TITLE
feat: Address missing commits and labels during changelog generation

### DIFF
--- a/pkg/gitlog/gitlog.go
+++ b/pkg/gitlog/gitlog.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 var (
@@ -14,21 +15,20 @@ var (
 )
 
 func GetHistory(path, start, end string) string {
-	logRange := fmt.Sprintf("%s..%s", start, end)
-
-	// get date from start (to handle cases where we merged git histories)
-	getStartDateCmd := exec.Command("git", "-C", path, "log", "-1", "--format=%ai", start)
-	log.Println(getStartDateCmd)
-	out, err := getStartDateCmd.CombinedOutput()
-	startDate := string(out)
+	err := validateAncestor(path, start, end)
 	if err != nil {
-		log.Fatal(startDate, err)
+		log.Fatal(err)
 	}
 
+	logRange := fmt.Sprintf("%s..%s", start, end)
+
 	// use git command til git lib implements range feature, see https://github.com/src-d/go-git/issues/1166
-	command := exec.Command("git", "-C", path, "log", logRange, "--merges", "--since", startDate, "--")
+	// Note: We removed the --since filter because it was incorrectly filtering out backported fixes
+	// that were committed before the start tag was released. The git revision range (start..end)
+	// already correctly determines which commits are new between revisions.
+	command := exec.Command("git", "-C", path, "log", logRange, "--merges", "--")
 	log.Println(command)
-	out, err = command.CombinedOutput()
+	out, err := command.CombinedOutput()
 	result := string(out)
 
 	if err != nil {
@@ -36,6 +36,21 @@ func GetHistory(path, start, end string) string {
 	}
 
 	return result
+}
+
+func validateAncestor(path, start, end string) error {
+	command := exec.Command("git", "-C", path, "merge-base", "--is-ancestor", start, end)
+	log.Println(command)
+	out, err := command.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+		return fmt.Errorf("invalid git range %s..%s: start is not an ancestor of end", start, end)
+	}
+
+	return fmt.Errorf("unable to validate git range %s..%s: %s (%w)", start, end, strings.TrimSpace(string(out)), err)
 }
 
 func ExtractIssueIds(message string) []int {

--- a/pkg/gitlog/gitlog_test.go
+++ b/pkg/gitlog/gitlog_test.go
@@ -11,6 +11,46 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func prepareDivergedRepo(t *testing.T) (string, string, string, string) {
+	t.Helper()
+	repoDir := filepath.Join(t.TempDir(), "diverged")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir temp repo: %v", err)
+	}
+
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "zcl-tests@example.com")
+	runGit(t, repoDir, "config", "user.name", "zcl-tests")
+
+	baseFile := filepath.Join(repoDir, "base.txt")
+	if err := os.WriteFile(baseFile, []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write base file: %v", err)
+	}
+	runGit(t, repoDir, "add", "base.txt")
+	runGit(t, repoDir, "commit", "-m", "base")
+	base := strings.TrimSpace(runGit(t, repoDir, "rev-parse", "HEAD"))
+
+	runGit(t, repoDir, "checkout", "-b", "branch-a")
+	aFile := filepath.Join(repoDir, "a.txt")
+	if err := os.WriteFile(aFile, []byte("a\n"), 0o644); err != nil {
+		t.Fatalf("write branch-a file: %v", err)
+	}
+	runGit(t, repoDir, "add", "a.txt")
+	runGit(t, repoDir, "commit", "-m", "branch-a")
+	branchA := strings.TrimSpace(runGit(t, repoDir, "rev-parse", "HEAD"))
+
+	runGit(t, repoDir, "checkout", "-b", "branch-b", base)
+	bFile := filepath.Join(repoDir, "b.txt")
+	if err := os.WriteFile(bFile, []byte("b\n"), 0o644); err != nil {
+		t.Fatalf("write branch-b file: %v", err)
+	}
+	runGit(t, repoDir, "add", "b.txt")
+	runGit(t, repoDir, "commit", "-m", "branch-b")
+	branchB := strings.TrimSpace(runGit(t, repoDir, "rev-parse", "HEAD"))
+
+	return repoDir, base, branchA, branchB
+}
+
 func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
@@ -63,7 +103,7 @@ func TestGitHistory(t *testing.T) {
 		needCamunda bool
 	}{
 		"First commit in zcl":          {path: ".", start: "7b86247", end: "7ab8381", size: 0},
-		"Between tags in camunda repo": {start: "8.5.0", end: "8.6.0-alpha1", size: 1559610, needCamunda: true},
+		"Between tags in camunda repo": {start: "8.5.0", end: "8.6.0-alpha1", size: 2012037, needCamunda: true},
 	}
 
 	var camundaRepo string
@@ -79,6 +119,27 @@ func TestGitHistory(t *testing.T) {
 
 			log := GetHistory(path, tc.start, tc.end)
 			assert.Equal(t, tc.size, len(log))
+		})
+	}
+}
+
+func TestRegressionBackportIssue40036IncludedInReleaseRanges(t *testing.T) {
+	tests := map[string]struct {
+		from           string
+		to             string
+		expectedCommit string
+	}{
+		"8.6.38 range": {from: "8.6.37", to: "8.6.38", expectedCommit: "87bbd207bc0fc7e7dbfbd0ffda36af6cc35c0b50"},
+		"8.7.25 range": {from: "8.7.24", to: "8.7.25", expectedCommit: "88bdb736007a93c6abeb1eb8a14093510c915af0"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			camundaRepo := prepareCamundaRepo(t, tc.from, tc.to)
+			history := GetHistory(camundaRepo, tc.from, tc.to)
+			assert.Contains(t, history, tc.expectedCommit)
+			issueIDs := ExtractIssueIds(history)
+			assert.Contains(t, issueIDs, 40036)
 		})
 	}
 }
@@ -124,4 +185,19 @@ func TestExtractIssueIds(t *testing.T) {
 			assert.Equal(t, tc.issueIds, issueIds)
 		})
 	}
+}
+
+func TestValidateAncestor(t *testing.T) {
+	repoDir, base, branchA, branchB := prepareDivergedRepo(t)
+
+	t.Run("valid ancestor", func(t *testing.T) {
+		err := validateAncestor(repoDir, base, branchA)
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-ancestor range", func(t *testing.T) {
+		err := validateAncestor(repoDir, branchA, branchB)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "start is not an ancestor")
+	})
 }


### PR DESCRIPTION
## Summary

This PR fixes a release-labeling/changelog regression where valid backported fixes were omitted from issue labeling and release notes, and adds a graph-safe guard for invalid revision ranges.

## Problem

`zcl add-labels`/history collection previously combined:

- commit range selection (`<from>..<to>`)
- time filtering (`--since <from-tag-date>`)

This caused false negatives for backports:
- a commit can be part of `<from>..<to>` by git ancestry
- but still have a timestamp earlier than `<from>` tag creation
- `--since` filtered it out incorrectly

Observed impact ([slack thread](https://camunda.slack.com/archives/C06UWQNCU7M/p1773811202289369)):
- issue `#40036` was missed for releases `8.6.38` and `8.7.25`
- corresponding version labels/release note entries were missing

## What Changed

### 1) Removed timestamp-based filtering from history collection
File: `pkg/gitlog/gitlog.go`

- History collection now relies on git graph range semantics (`<from>..<to>`) instead of time filtering.
- This ensures valid backported commits are included even when commit time is earlier than the previous tag timestamp.

### 2) Added ancestry validation guard before collecting history
File: `pkg/gitlog/gitlog.go`

- Added `validateAncestor(path, start, end)` using:
  - `git merge-base --is-ancestor <start> <end>`
- `GetHistory` now validates the range before running `git log`.
- If `start` is not an ancestor of `end`, we fail fast with a clear message.

Why:
- replacing `--since` removed a bad guard
- ancestry validation adds a correct guard based on graph topology
- protects against invalid/diverged ranges without reintroducing time-based false negatives

### 3) Updated/added tests
File: `pkg/gitlog/gitlog_test.go`

- Updated expected output size for:
  - `"Between tags in camunda repo"` from old filtered output to range-only output (`2012037`)
- Added regression test proving exact commits and issue extraction for the incident:
  - `8.6.37..8.6.38` contains commit `87bbd207bc0fc7e7dbfbd0ffda36af6cc35c0b50`
  - `8.7.24..8.7.25` contains commit `88bdb736007a93c6abeb1eb8a14093510c915af0`
  - both ranges extract issue `#40036`
- Added `TestValidateAncestor` with a synthetic diverged repo (`prepareDivergedRepo`) to verify:
  - valid ancestor range passes
  - non-ancestor range fails with expected error

## Reasoning

### Why remove `--since`
- release membership is a graph problem, not a timestamp problem
- commit dates are not reliable for backport inclusion decisions
- time-based filtering caused real production misses

### Why add ancestry validation
- we still need protection for malformed ranges / mixed histories
- `merge-base --is-ancestor` enforces correct release-range topology
- this guard is strict and deterministic, and does not drop valid backports

## Validation

- `go test -mod=vendor ./pkg/gitlog` passes
- `make test` passes

## Impact

- Backported fixes are no longer silently dropped due to timestamp skew
- Invalid non-ancestor ranges fail fast with actionable errors
- Regression coverage now protects both:
  - incident-specific behavior (`#40036`)
  - topology guard behavior (ancestor vs non-ancestor)

Related to https://github.com/camunda/camunda/issues/49709