### PR TITLE
fix: relax requirements to history ancestry and handle deletes issues gracefully

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -81,10 +81,12 @@ func (ghc *Client) LabelExists(githubOrg, githubRepo, label string) (bool, error
 func (ghc *Client) AddLabel(githubOrg string, githubRepo string, issueId int, label string) {
 	_, _, err := ghc.client.Issues.AddLabelsToIssue(ghc.ctx, githubOrg, githubRepo, issueId, []string{label})
 	if err != nil {
-		// Check if the error is a 404 Not Found error
-		if errResp, ok := err.(*github.ErrorResponse); ok && errResp.Response.StatusCode == http.StatusNotFound {
-			log.Printf("Warning: Issue #%d not found in %s/%s, skipping label addition\n", issueId, githubOrg, githubRepo)
-			return
+		if errResp, ok := err.(*github.ErrorResponse); ok && errResp.Response != nil {
+			if errResp.Response.StatusCode == http.StatusNotFound ||
+				errResp.Response.StatusCode == http.StatusUnprocessableEntity {
+				log.Printf("Warning: Issue #%d could not be labeled in %s/%s, skipping label addition: %v\n", issueId, githubOrg, githubRepo, err)
+				return
+			}
 		}
 		log.Fatalln(err)
 	}

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -47,8 +47,48 @@ func TestAddLabel_404Error(t *testing.T) {
 
 	// Verify that a warning was logged instead of a fatal error
 	logOutput := buf.String()
-	if !strings.Contains(logOutput, "Warning: Issue #12345 not found") {
+	if !strings.Contains(logOutput, "Warning: Issue #12345 could not be labeled") {
 		t.Errorf("Expected warning message in log output, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "404 Not Found") {
+		t.Errorf("Expected not-found details in log output, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "testorg/testrepo") {
+		t.Errorf("Expected org/repo in log output, got: %s", logOutput)
+	}
+}
+
+func TestAddLabel_422MissingNodeWarns(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"message":"Validation Failed","errors":[{"resource":"Label","field":"data","code":"unprocessable","message":"Could not resolve to a node with the global id of 'I_kwDOAzyJQs73cw6O'."}]}`))
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
+
+	client := github.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL + "/")
+	client.BaseURL = baseURL
+
+	ghc := &Client{
+		client: client,
+		ctx:    context.Background(),
+	}
+
+	ghc.AddLabel("testorg", "testrepo", 49820, "test-label")
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "Warning: Issue #49820 could not be labeled") {
+		t.Errorf("Expected warning message in log output, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "Could not resolve to a node") {
+		t.Errorf("Expected missing-node error details in log output, got: %s", logOutput)
 	}
 	if !strings.Contains(logOutput, "testorg/testrepo") {
 		t.Errorf("Expected org/repo in log output, got: %s", logOutput)

--- a/pkg/gitlog/gitlog.go
+++ b/pkg/gitlog/gitlog.go
@@ -47,7 +47,8 @@ func validateAncestor(path, start, end string) error {
 	}
 
 	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
-		return fmt.Errorf("invalid git range %s..%s: start is not an ancestor of end", start, end)
+		log.Printf("warning: git range %s..%s has start that is not an ancestor of end; continuing anyway", start, end)
+		return nil
 	}
 
 	return fmt.Errorf("unable to validate git range %s..%s: %s (%w)", start, end, strings.TrimSpace(string(out)), err)

--- a/pkg/gitlog/gitlog_test.go
+++ b/pkg/gitlog/gitlog_test.go
@@ -197,7 +197,13 @@ func TestValidateAncestor(t *testing.T) {
 
 	t.Run("non-ancestor range", func(t *testing.T) {
 		err := validateAncestor(repoDir, branchA, branchB)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "start is not an ancestor")
+		assert.NoError(t, err)
 	})
+}
+
+func TestGetHistoryAllowsNonAncestorRanges(t *testing.T) {
+	repoDir, _, branchA, branchB := prepareDivergedRepo(t)
+
+	history := GetHistory(repoDir, branchA, branchB)
+	assert.Equal(t, "", history)
 }


### PR DESCRIPTION
**GitHub Label Addition Improvements:**

* Updated `AddLabel` in `client.go` to treat both 404 (Not Found) and 422 (Unprocessable Entity) errors as warnings, logging the error details. This makes the function more robust to common GitHub API edge cases.

**Git Range Validation Improvements:**

* Modified `validateAncestor` in `gitlog.go` to log a warning and continue when the git range start is not an ancestor of end, instead of returning an error. This is a follow-up on softening the restrictions added in #37

Related: https://camunda.slack.com/archives/C06UWQNCU7M/p1775564130264149