### PR TITLE
feat: include support labeled issues without kind/ label into release notes

### DIFF
--- a/pkg/github/issue.go
+++ b/pkg/github/issue.go
@@ -16,6 +16,7 @@ const (
 	docsLabel       = "kind/documentation"
 	toilLabel       = "kind/toil"
 	taskLabel       = "kind/task"
+	supportLabel    = "support"
 )
 
 var knownLabels = []string{
@@ -29,6 +30,7 @@ var knownLabels = []string{
 	zbctlLabel,
 	toilLabel,
 	taskLabel,
+	supportLabel,
 }
 
 type Issue struct {
@@ -83,7 +85,7 @@ func (i *Issue) HasEnhancementLabel() bool {
 }
 
 func (i *Issue) HasBugLabel() bool {
-	return i.hasLabel(bugLabel)
+	return i.hasLabel(bugLabel) || i.hasLabel(supportLabel)
 }
 
 func (i *Issue) HasDocsLabel() bool {


### PR DESCRIPTION
example: https://github.com/camunda/camunda/issues/52078 was not included in https://github.com/camunda/camunda/releases/tag/8.9.4